### PR TITLE
Replace sudo with doas

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ a `yad` command displaying the amount of time left before shutdown.
 5.
 
 * `-S [command]`: Command to run when shutting down, passed to `sh -c`.
-Defaults to `sudo halt -p`.  `sudoers` should allow access to halt without a
-password (`%wheel ALL = /sbin/halt NOPASSWD`) for this to work.
+Defaults to `doas halt -p`.  `doas.conf` should allow access to halt without a
+password (`permit nopass :%wheel cmd /sbin/halt`) for this to work.
 
 ####License
 

--- a/shutdownd.c
+++ b/shutdownd.c
@@ -51,7 +51,7 @@
 				"<b>$shutdown_minutes</b>.\""
 
 #define	DEFAULT_SHUTDOWN_MINS	5
-#define	DEFAULT_SHUTDOWN_CMD	"/usr/bin/sudo /sbin/halt -p"
+#define	DEFAULT_SHUTDOWN_CMD	"/usr/bin/doas /sbin/halt -p"
 
 extern char *__progname;
 


### PR DESCRIPTION
With the replacement of sudo in base with doas, this change updates shutdownd to use doas in base.